### PR TITLE
tune the scrollbar display of mobile page

### DIFF
--- a/static/sspanel/css/ehco.css
+++ b/static/sspanel/css/ehco.css
@@ -23,3 +23,8 @@
 #nav-toggle-state:checked~.nav-menu {
     display: block;
 }
+
+body {
+    /* On modern browsers, prevent the whole page to bounce */
+    overflow: hidden;
+}


### PR DESCRIPTION
issue #31 
解决在一些移动端浏览器上显示页面时滚动条所占区域的问题。
如下图中红色框区域：
![django-sspanel-scrollbar-display-bug](https://user-images.githubusercontent.com/1780731/33004086-c26c62f4-cdf9-11e7-97d8-9e883ffdb4fe.PNG)
后如下：
![finished](https://user-images.githubusercontent.com/1780731/33004161-1cc347a4-cdfa-11e7-8bb4-02aad2561407.PNG)
