### PR TITLE
optimized Docker image

### DIFF
--- a/configs/default/db.py
+++ b/configs/default/db.py
@@ -5,7 +5,8 @@ DATABASES = {
         'NAME': 'sspanel',
         'USER': 'root',
         'PASSWORD': '',
-        'HOST': '127.0.0.1',
+        'HOST': '127.0.0.1',  # 正常版本使用
+        # 'HOST': 'db',       # docker版本使用
         'PORT': '3306',
         'OPTIONS': {
             'autocommit': True,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,19 +15,14 @@ services:
       - sspanel_network
   web:
     container_name : sspanel-web
-    build:
-      context: .
-      dockerfile: Dockerfile
+    build: .
     image: sspanel
     environment:
       MYSQL_PASSWORD: yourpass
       MYSQL_HOST: db
-    command: uwsgi uwsgi.ini
     volumes:
       - .:/src/django-sspanel
-      - static/:/src/django-sspanel/static
-    ports:
-      - 8080:8080
+      - static:/src/django-sspanel/static
     depends_on:
       - db
     networks:
@@ -38,7 +33,7 @@ services:
     container_name : sspanel-nginx
     volumes:
       - ./configs/nginx/:/etc/nginx/conf.d
-      - static/:/src/django-sspanel/static
+      - static:/src/django-sspanel/static
     ports:
       - 80:80
     depends_on:


### PR DESCRIPTION
This commit optimizes the Docker version. 

The Docker image build process is changed in the following ways:
- Image is now based on `python:3.6-slim-stretch`. This reduces image size from 1 GB to 250 MB.
- Port 8080 of `uwsgi` will no longer be open to the world
- The django app itself will no longer run as a non-root user. [Reference: Processes In Containers Should Not Run As Root
](https://medium.com/@mccode/processes-in-containers-should-not-run-as-root-2feae3f0df3b)
- The `static` folder will now be a Docker volume, instead of binding a directory on the host.
- Some minor cleanups in `docker-compose.yml`