### PR TITLE
perf(apps/extensions): set global alipay url for alipay extensions

### DIFF
--- a/apps/extensions/alipay.py
+++ b/apps/extensions/alipay.py
@@ -15,6 +15,7 @@ class Pay:
             alipay_public_key_string=settings.ALIPAY_PUBLIC_KEY_STRING,
             config=AliPayConfig(timeout=3),
         )
+        self.alipay._gateway = "https://globalopenapi.alipay.com/gateway.do"
 
     def trade_precreate(
         self, out_trade_no, total_amount, subject, timeout_express, notify_url


### PR DESCRIPTION
Maybe most `sspanel` be deployed on the server whose location is not the mainland, therefore use the global Alipay URL